### PR TITLE
Fix for missing content* headers in S3UploadPartRequest

### DIFF
--- a/src/Amazon.S3/Model/S3UploadPartRequest.m
+++ b/src/Amazon.S3/Model/S3UploadPartRequest.m
@@ -37,11 +37,15 @@
 {
     self.subResource = [NSString stringWithFormat:@"%@=%d&%@=%@", kS3QueryParamPartNumber, self.partNumber, kS3QueryParamUploadId, self.uploadId];
 
+    if (self.contentLength < 1) {
+        self.contentLength = [data length];
+    }
+
     [super configureURLRequest];
 
     [self.urlRequest setHTTPBody:self.data];
-    if (self.contentLength < 1) {
-        self.contentLength = [data length];
+    if (nil != self.contentMD5) {
+        [self.urlRequest setValue:self.contentMD5 forHTTPHeaderField:kHttpHdrContentMD5];
     }
 
     [urlRequest setHTTPMethod:kHttpMethodPut];


### PR DESCRIPTION
Content-Length and Content-MD5 headers were not being set for the URLRequest created by S3UploadPartRequest, which causes the part upload to fail.
