### PR TITLE
Comment on buggy / misleading implementation of abortMultipartUploadWithUploadId:

### DIFF
--- a/src/Amazon.S3/AmazonS3Client.m
+++ b/src/Amazon.S3/AmazonS3Client.m
@@ -273,6 +273,9 @@
     return (S3AbortMultipartUploadResponse *)[self invoke:abortMultipartUploadRequest];
 }
 
+// This method is misleading.  It will always fail, because aborting a multipart upload
+// requires not just the upload ID but also the key and the bucket, which are used in the URL
+// and in signing the request.  If you keep this method, it should take those two values as parameters.
 -(void)abortMultipartUploadWithUploadId:(NSString *)theUploadId
 {
     S3AbortMultipartUploadRequest *request = [[[S3AbortMultipartUploadRequest alloc] init] autorelease];


### PR DESCRIPTION
The helper method abortMultipartUploadWithUploadId: in AmazonS3Client for aborting a multipart upload is misleading and buggy.  Here's my comment from the pull request:

This method is misleading.  It will always fail, because aborting a multipart upload requires not just the upload ID but also the key and the bucket, which are used in the URL and in signing the request.  If you keep this method, it should take those two values as parameters.
