### PR TITLE
Check for nil before calling inputStreamWithData:

### DIFF
--- a/src/Amazon.S3/Model/S3UploadInputStream.m
+++ b/src/Amazon.S3/Model/S3UploadInputStream.m
@@ -35,7 +35,9 @@
 +(id)inputStreamWithData:(NSData *)data
 {
 	S3UploadInputStream *uploadStream = [[[S3UploadInputStream alloc] init] autorelease];
-	[uploadStream setStream:[NSInputStream inputStreamWithData:data]];
+	if (data) {
+		[uploadStream setStream:[NSInputStream inputStreamWithData:data]];
+	}
 	return uploadStream;
 }
 


### PR DESCRIPTION
This just checks to make sure data is not nil before initializing an NSInputStream. Note that the framework will still crash if you pass nil, but now it will crash with useful error messages being logged.
