### PR TITLE
Fix a serialisation error

### DIFF
--- a/src/Amazon.S3/Model/S3Grantee.m
+++ b/src/Amazon.S3/Model/S3Grantee.m
@@ -50,7 +50,7 @@
     static S3Grantee *allUsers = nil;
 
     if (allUsers == nil) {
-        @synchronized(allUsers) {
+        @synchronized(self) {
             if (allUsers == nil) {
                 allUsers = [[S3Grantee granteeWithURI:kS3GroupURIAllUsers] retain];
             }
@@ -64,7 +64,7 @@
     static S3Grantee *authUsers = nil;
 
     if (authUsers == nil) {
-        @synchronized(authUsers) {
+        @synchronized(self) {
             if (authUsers == nil) {
                 authUsers = [[S3Grantee granteeWithURI:kS3GroupURIAuthUsers] retain];
             }


### PR DESCRIPTION
You cannot use @synchronized(A) when A is nil; in the sections of code I corrected A is guaranteed to be nil in at least one thread, leading to concurrent execution of the supposedly synchronized block. I have corrected this.
