### PR TITLE
Partial support for range keys in Core Data.

### DIFF
--- a/src-persistence/AWSPersistenceDynamoDBIncrementalStore.h
+++ b/src-persistence/AWSPersistenceDynamoDBIncrementalStore.h
@@ -18,6 +18,7 @@
 
 extern NSString *const AWSPersistenceDynamoDBIncrementalStoreType;
 extern NSString *const AWSPersistenceDynamoDBHashKey;
+extern NSString *const AWSPersistenceDynamoDBRangeKey;
 extern NSString *const AWSPersistenceDynamoDBVersionKey;
 extern NSString *const AWSPersistenceDynamoDBDelegate;
 extern NSString *const AWSPersistenceDynamoDBTableMapper;

--- a/src-persistence/AWSPersistenceDynamoDBIncrementalStore.m
+++ b/src-persistence/AWSPersistenceDynamoDBIncrementalStore.m
@@ -133,15 +133,15 @@ NSString *const AWSPersistenceDynamoDBUserAgentPrefix = @"Persistence Framework"
                     }
                 }
             }
-            // @duckmaestro: HashKey+RangeKey fetch or query
+            // HashKey+RangeKey fetch or query
             else if([fetchRequest.predicate isKindOfClass:[NSCompoundPredicate class]])
             {
                 NSCompoundPredicate *predicate = (NSCompoundPredicate *)fetchRequest.predicate;
                 if([predicate compoundPredicateType] == NSAndPredicateType
                    && [[predicate subpredicates] count] == 2)
                 {
-                    NSComparisonPredicate* leftPredicate = [[predicate subpredicates] objectAtIndex:0];
-                    NSComparisonPredicate* rightPredicate = [[predicate subpredicates] objectAtIndex:1];
+                    NSComparisonPredicate *leftPredicate = [[predicate subpredicates] objectAtIndex:0];
+                    NSComparisonPredicate *rightPredicate = [[predicate subpredicates] objectAtIndex:1];
 
                     if([[[leftPredicate leftExpression] keyPath] isEqualToString:entityHashKeyName]
                        && [[[rightPredicate leftExpression] keyPath] isEqualToString:entityRangeKeyName])
@@ -174,7 +174,7 @@ NSString *const AWSPersistenceDynamoDBUserAgentPrefix = @"Persistence Framework"
                                 && rightPredicate.predicateOperatorType == NSBetweenPredicateOperatorType)
                         {
                             id hashKeyValue = [[leftPredicate rightExpression] expressionValueWithObject:nil context:nil];
-                            NSArray* rangeKeyLimits = [[rightPredicate rightExpression] expressionValueWithObject:nil context:nil];
+                            NSArray *rangeKeyLimits = [[rightPredicate rightExpression] expressionValueWithObject:nil context:nil];
                             id rangeKeyMin = [rangeKeyLimits objectAtIndex:0];
                             id rangeKeyMax = [rangeKeyLimits objectAtIndex:1];
                             uint limit = fetchRequest.fetchLimit;
@@ -289,7 +289,7 @@ NSString *const AWSPersistenceDynamoDBUserAgentPrefix = @"Persistence Framework"
         id hashUnknown = [objectIdToHashKey valueForKey:objectID.URIRepresentation.description];
         if([hashUnknown isKindOfClass:[NSDictionary class]])
         {
-            // @duckmaestro: hash + range key
+            // hash + range key
             NSDictionary *compositeHash = hashUnknown;
             
             DynamoDBAttributeValue *attributeValueHashKey = [self attributeValueFromObject:[compositeHash objectForKey:@"hashKey"]];
@@ -508,7 +508,7 @@ NSString *const AWSPersistenceDynamoDBUserAgentPrefix = @"Persistence Framework"
 {
     AMZLogDebug(@"- (NSArray *)obtainPermanentIDsForObjects:(NSArray *)array error:(NSError **)error called.");
 
-    // @duckmaestro-todo: modify to support range key if present.
+    // todo: if needed, modify to support range key.
     
     NSMutableArray *resultArray = [NSMutableArray arrayWithCapacity:[array count]];
     for(NSManagedObject *managedObject in array)

--- a/src-persistence/AWSPersistenceDynamoDBIncrementalStore.m
+++ b/src-persistence/AWSPersistenceDynamoDBIncrementalStore.m
@@ -20,6 +20,7 @@
 // Public Constants
 NSString *const AWSPersistenceDynamoDBIncrementalStoreType = @"AWSPersistenceDynamoDBIncrementalStore";
 NSString *const AWSPersistenceDynamoDBHashKey = @"hashKeys";
+NSString *const AWSPersistenceDynamoDBRangeKey = @"rangeKeys";
 NSString *const AWSPersistenceDynamoDBVersionKey = @"versions";
 NSString *const AWSPersistenceDynamoDBDelegate = @"delegate";
 NSString *const AWSPersistenceDynamoDBTableMapper = @"tableMapper";
@@ -91,6 +92,9 @@ NSString *const AWSPersistenceDynamoDBUserAgentPrefix = @"Persistence Framework"
     if (request.requestType == NSFetchRequestType)
     {
         NSFetchRequest *fetchRequest = (NSFetchRequest *) request;
+        NSString *entityHashKeyName = [self hashKeyForEntityName:fetchRequest.entity.name];
+        NSString *entityRangeKeyName = [self rangeKeyForEntityName:fetchRequest.entity.name];
+        
         if (fetchRequest.resultType == NSManagedObjectResultType)
         {
             NSMutableArray *resultArray = [NSMutableArray array];
@@ -113,7 +117,7 @@ NSString *const AWSPersistenceDynamoDBUserAgentPrefix = @"Persistence Framework"
             {
                 NSComparisonPredicate *predicate = (NSComparisonPredicate *)fetchRequest.predicate;
 
-                if([[[predicate leftExpression] keyPath] isEqualToString:[self hashKeyForEntityName:fetchRequest.entity.name]])
+                if([[[predicate leftExpression] keyPath] isEqualToString:entityHashKeyName])
                 {
                     NSMutableArray *getItemResult = [self getItem:fetchRequest
                                                       withContext:context
@@ -129,6 +133,83 @@ NSString *const AWSPersistenceDynamoDBUserAgentPrefix = @"Persistence Framework"
                     }
                 }
             }
+            // @duckmaestro: HashKey+RangeKey fetch or query
+            else if([fetchRequest.predicate isKindOfClass:[NSCompoundPredicate class]])
+            {
+                NSCompoundPredicate *predicate = (NSCompoundPredicate *)fetchRequest.predicate;
+                if([predicate compoundPredicateType] == NSAndPredicateType
+                   && [[predicate subpredicates] count] == 2)
+                {
+                    NSComparisonPredicate* leftPredicate = [[predicate subpredicates] objectAtIndex:0];
+                    NSComparisonPredicate* rightPredicate = [[predicate subpredicates] objectAtIndex:1];
+
+                    if([[[leftPredicate leftExpression] keyPath] isEqualToString:entityHashKeyName]
+                       && [[[rightPredicate leftExpression] keyPath] isEqualToString:entityRangeKeyName])
+                    {
+                        // simple equality
+                        if(leftPredicate.predicateOperatorType == NSEqualToPredicateOperatorType
+                           && rightPredicate.predicateOperatorType == NSEqualToPredicateOperatorType)
+                        {
+                                
+                            id hashKeyValue = [[leftPredicate rightExpression] expressionValueWithObject:nil context:nil];
+                            id rangeKeyValue = [[rightPredicate rightExpression] expressionValueWithObject:nil context:nil];
+                            
+                            NSMutableArray *getItemResult = [self getItem:fetchRequest
+                                                              withContext:context
+                                                              withHashKey:hashKeyValue
+                                                             withRangeKey:rangeKeyValue
+                                                                    error:error];
+                            if(getItemResult != nil)
+                            {
+                                [resultArray addObjectsFromArray:getItemResult];
+                            }
+                            else
+                            {
+                                return nil;
+                            }
+                           
+                        }
+                        // equality + range query
+                        else if(leftPredicate.predicateOperatorType == NSEqualToPredicateOperatorType
+                                && rightPredicate.predicateOperatorType == NSBetweenPredicateOperatorType)
+                        {
+                            id hashKeyValue = [[leftPredicate rightExpression] expressionValueWithObject:nil context:nil];
+                            NSArray* rangeKeyLimits = [[rightPredicate rightExpression] expressionValueWithObject:nil context:nil];
+                            id rangeKeyMin = [rangeKeyLimits objectAtIndex:0];
+                            id rangeKeyMax = [rangeKeyLimits objectAtIndex:1];
+                            uint limit = fetchRequest.fetchLimit;
+                            BOOL sortAscending = YES;
+                            
+                            if(fetchRequest.sortDescriptors != nil && fetchRequest.sortDescriptors.count > 0)
+                            {
+                                NSSortDescriptor *sortDescriptor = [fetchRequest.sortDescriptors objectAtIndex:0];
+                                if([sortDescriptor.key isEqualToString:entityRangeKeyName])
+                                {
+                                    sortAscending = sortDescriptor.ascending;
+                                }
+                            }
+                            
+                            NSMutableArray *queryResult = [self query:fetchRequest
+                                                           withContext:context
+                                                          withHashKey:hashKeyValue
+                                                      withRangeKeyMin:rangeKeyMin
+                                                       andRangeKeyMax:rangeKeyMax
+                                                        sortAscending:sortAscending
+                                                                limit:limit
+                                                                error:error];
+                            if(queryResult != nil)
+                            {
+                                [resultArray addObjectsFromArray:queryResult];
+                            }
+                            else
+                            {
+                                return nil;
+                            }
+                        }
+                    }
+                }
+            }
+
 
             return resultArray;
         }
@@ -203,8 +284,25 @@ NSString *const AWSPersistenceDynamoDBUserAgentPrefix = @"Persistence Framework"
 
     @try
     {
-        DynamoDBAttributeValue *attributeValue = [self attributeValueFromObject:[objectIdToHashKey valueForKey:objectID.URIRepresentation.description]];
-        DynamoDBKey *key = [[DynamoDBKey alloc] initWithHashKeyElement:attributeValue];
+        DynamoDBKey *key;
+        
+        id hashUnknown = [objectIdToHashKey valueForKey:objectID.URIRepresentation.description];
+        if([hashUnknown isKindOfClass:[NSDictionary class]])
+        {
+            // @duckmaestro: hash + range key
+            NSDictionary *compositeHash = hashUnknown;
+            
+            DynamoDBAttributeValue *attributeValueHashKey = [self attributeValueFromObject:[compositeHash objectForKey:@"hashKey"]];
+            DynamoDBAttributeValue *attributeValueRangeKey = [self attributeValueFromObject:[compositeHash objectForKey:@"rangeKey"]];
+            key = [[DynamoDBKey alloc] initWithHashKeyElement:attributeValueHashKey andRangeKeyElement:attributeValueRangeKey];
+        }
+        else
+        {
+            // just hash key
+            DynamoDBAttributeValue *attributeValue = [self attributeValueFromObject:hashUnknown];
+            key = [[DynamoDBKey alloc] initWithHashKeyElement:attributeValue];
+        }
+        
         DynamoDBGetItemRequest *getItemRequest = [[DynamoDBGetItemRequest alloc] initWithTableName:[self tableNameForEntityName:objectID.entity.name]
                                                                                             andKey:key];
         getItemRequest.consistentRead = YES;
@@ -410,6 +508,8 @@ NSString *const AWSPersistenceDynamoDBUserAgentPrefix = @"Persistence Framework"
 {
     AMZLogDebug(@"- (NSArray *)obtainPermanentIDsForObjects:(NSArray *)array error:(NSError **)error called.");
 
+    // @duckmaestro-todo: modify to support range key if present.
+    
     NSMutableArray *resultArray = [NSMutableArray arrayWithCapacity:[array count]];
     for(NSManagedObject *managedObject in array)
     {
@@ -465,27 +565,54 @@ NSString *const AWSPersistenceDynamoDBUserAgentPrefix = @"Persistence Framework"
             {
                 for(NSDictionary *dic in response.items)
                 {
-                    DynamoDBAttributeValue *attributeValue = (DynamoDBAttributeValue *)[dic objectForKey:[self hashKeyForEntityName:request.entity.name]];
-
-                    NSString *hashKey;
-
-                    if(attributeValue.s != nil)
+                    NSString *hashKeyRetrieved;
+                    NSString *rangeKeyRetrieved;
+                    
+                    DynamoDBAttributeValue *attributeValueHashKey = (DynamoDBAttributeValue *)[dic objectForKey:[self hashKeyForEntityName:request.entity.name]];
+                    if(attributeValueHashKey.s != nil)
                     {
-                        hashKey = attributeValue.s;
+                        hashKeyRetrieved = attributeValueHashKey.s;
                     }
-                    else if(attributeValue.n != nil)
+                    else if(attributeValueHashKey.n != nil)
                     {
-                        hashKey = attributeValue.n;
+                        hashKeyRetrieved = attributeValueHashKey.n;
                     }
-
-                    id hashKeyObject = [self convertString:hashKey toClass:[attributeClasses objectForKey:[self hashKeyForEntityName:request.entity.name]]];
-
-                    NSManagedObjectID *objectId = [self newObjectIDForEntity:request.entity
-                                                             referenceObject:hashKeyObject];
+                    
+                    DynamoDBAttributeValue *attributeValueRangeKey = nil;
+                    attributeValueRangeKey = (DynamoDBAttributeValue *)[dic objectForKey:[self rangeKeyForEntityName:request.entity.name]];
+                    if(attributeValueRangeKey != nil)
+                    {
+                        if(attributeValueRangeKey.s != nil)
+                        {
+                            rangeKeyRetrieved = attributeValueRangeKey.s;
+                        }
+                        else if(attributeValueRangeKey.n != nil)
+                        {
+                            rangeKeyRetrieved = attributeValueRangeKey.n;
+                        }
+                    }
+                    
+                    
+                    id hashKeyObject = [self convertString:hashKeyRetrieved toClass:[attributeClasses objectForKey:[self hashKeyForEntityName:request.entity.name]]];
+                    id rangeKeyObject = nil;
+                    if(rangeKeyRetrieved != nil)
+                    {
+                        rangeKeyObject = [self convertString:rangeKeyRetrieved toClass:[attributeClasses objectForKey:[self rangeKeyForEntityName:request.entity.name]]];
+                    }
+                    
+                    id key;
+                    if(rangeKeyObject == nil)
+                    {
+                        key = hashKeyObject;
+                    }
+                    else
+                    {
+                        key = [NSDictionary dictionaryWithObjectsAndKeys:hashKeyObject, @"hashKey", rangeKeyObject, @"rangeKey", nil];
+                    }
+                    
+                    NSManagedObjectID *objectId = [self newObjectIDForEntity:request.entity referenceObject:[self referenceObjectIdForCoreData:key]];
                     NSManagedObject *managedObject = [context objectWithID:objectId];
-
-                    [objectIdToHashKey setValue:hashKeyObject forKey:objectId.URIRepresentation.description];
-
+                    [objectIdToHashKey setValue:key forKey:objectId.URIRepresentation.description];
                     [resultArray addObject:managedObject];
                 }
 
@@ -507,19 +634,152 @@ NSString *const AWSPersistenceDynamoDBUserAgentPrefix = @"Persistence Framework"
     }
 }
 
+- (NSMutableArray *)query:(NSFetchRequest *)request withContext:(NSManagedObjectContext *)context withHashKey:(id)hashKey withRangeKeyMin:(id)rangeKeyMin andRangeKeyMax:(id)rangeKeyMax sortAscending:(BOOL)ascending limit:(int)limit error:(NSError **)error
+{
+    AMZLogDebug(@"- (NSMutableArray *)query:(NSFetchRequest *)request withContext:(NSManagedObjectContext *)context withHashKey:(id)hashKey withRangeKeyMin:(id)rangeKeyMin andRangeKeyMax:(id)rangeKeyMax sortAscending:(BOOL)ascending error:(NSError **)error called.");
+    @try
+    {
+        NSMutableArray *resultArray = [NSMutableArray array];
+        NSMutableArray *attributesToGet = [NSMutableArray array];
+ 
+        [attributesToGet addObject:[self hashKeyForEntityName:request.entity.name]];
+        [attributesToGet addObject:[self rangeKeyForEntityName:request.entity.name]];
+        
+        DynamoDBAttributeValue *attributeValueHashKeyValue = [self attributeValueFromObject:hashKey];        
+        DynamoDBAttributeValue *attributeValueRangeMinValue = [self attributeValueFromObject:rangeKeyMin];
+        DynamoDBAttributeValue *attributeValueRangeMaxValue = [self attributeValueFromObject:rangeKeyMax];
+        
+        DynamoDBQueryRequest *queryRequest  = [[DynamoDBQueryRequest alloc] initWithTableName:[self tableNameForEntityName:request.entityName] andHashKeyValue:attributeValueHashKeyValue];
+        queryRequest.attributesToGet = attributesToGet;
+        queryRequest.rangeKeyCondition = [[DynamoDBCondition alloc] init];
+        queryRequest.rangeKeyCondition.attributeValueList =
+            [[NSMutableArray alloc] initWithObjects:attributeValueRangeMinValue, attributeValueRangeMaxValue, nil];
+        queryRequest.rangeKeyCondition.comparisonOperator = @"BETWEEN";
+        queryRequest.scanIndexForward = ascending;
+        queryRequest.limit = [NSNumber numberWithInt:limit];
+        
+        DynamoDBKey *lastEvaluatedKey = nil;
+        DynamoDBQueryResponse *response = nil;
+        
+        NSDictionary *attributeClasses = [self attributeClassesForClassName:request.entityName];
+        
+        
+        int itemCount = 0;
+        do {
+            queryRequest.exclusiveStartKey = lastEvaluatedKey;
+            
+            AmazonDynamoDBClient *dynamoDBClient = [self dynamoDBClient];
+            response = [dynamoDBClient query:queryRequest];
+            
+            if(response.error == nil)
+            {
+                for(NSDictionary *dic in response.items)
+                {
+                    NSString *hashKeyRetrieved;
+                    NSString *rangeKeyRetrieved;
+                    
+                    DynamoDBAttributeValue *attributeValueHashKey = (DynamoDBAttributeValue *)[dic objectForKey:[self hashKeyForEntityName:request.entity.name]];
+                    if(attributeValueHashKey.s != nil)
+                    {
+                        hashKeyRetrieved = attributeValueHashKey.s;
+                    }
+                    else if(attributeValueHashKey.n != nil)
+                    {
+                        hashKeyRetrieved = attributeValueHashKey.n;
+                    }
+
+                    DynamoDBAttributeValue *attributeValueRangeKey = nil;
+                    attributeValueRangeKey = (DynamoDBAttributeValue *)[dic objectForKey:[self rangeKeyForEntityName:request.entity.name]];
+                    
+                    if(attributeValueRangeKey.s != nil)
+                    {
+                        rangeKeyRetrieved = attributeValueRangeKey.s;
+                    }
+                    else if(attributeValueRangeKey.n != nil)
+                    {
+                        rangeKeyRetrieved = attributeValueRangeKey.n;
+                    }
+                    
+                    id hashKeyObject = [self convertString:hashKeyRetrieved toClass:[attributeClasses objectForKey:[self hashKeyForEntityName:request.entity.name]]];
+                    id rangeKeyObject = [self convertString:rangeKeyRetrieved toClass:[attributeClasses objectForKey:[self rangeKeyForEntityName:request.entity.name]]];
+                    
+                    id key;
+                    if(rangeKeyObject == nil)
+                    {
+                        key = hashKeyObject;
+                    }
+                    else
+                    {
+                        key = [NSDictionary dictionaryWithObjectsAndKeys:hashKeyObject, @"hashKey", rangeKeyObject, @"rangeKey", nil];
+                    }
+                    
+                    NSManagedObjectID *objectId = [self newObjectIDForEntity:request.entity referenceObject:[self referenceObjectIdForCoreData:key]];
+                    NSManagedObject *managedObject = [context objectWithID:objectId];
+                    [objectIdToHashKey setValue:key forKey:objectId.URIRepresentation.description];
+                    
+                    [resultArray addObject:managedObject];
+                    ++itemCount;
+                    if(itemCount >= limit)
+                    {
+                        lastEvaluatedKey = nil;
+                        break;
+                    }
+                }
+                
+                lastEvaluatedKey = response.lastEvaluatedKey;
+            }
+            else
+            {
+                *error = response.error;
+                return nil;
+            }
+        } while (lastEvaluatedKey != nil);
+        
+        return resultArray;
+    }
+    @catch (NSException *exception)
+    {
+        *error = [self errorFromException:exception];
+        return nil;
+    }
+}
+
 - (NSMutableArray *)getItem:(NSFetchRequest *)request withContext:(NSManagedObjectContext *)context withHashKey:(id)hashKey error:(NSError **)error
+{
+    return [self getItem:request withContext:context withHashKey:hashKey withRangeKey:nil error:error];
+}
+
+- (NSMutableArray *)getItem:(NSFetchRequest *)request withContext:(NSManagedObjectContext *)context withHashKey:(id)hashKey withRangeKey:(id)rangeKey error:(NSError **)error
 {
     AMZLogDebug(@"- (NSMutableArray *)getItem:(NSFetchRequest *)request withContext:(NSManagedObjectContext *)context withHashKey:(NSString *)hashKey error:(NSError **)error called.");
     @try
     {
         NSMutableArray *resultArray = [NSMutableArray array];
 
-        DynamoDBAttributeValue *attributeValue = [self attributeValueFromObject:hashKey];
-        DynamoDBKey *key = [[DynamoDBKey alloc] initWithHashKeyElement:attributeValue];
+        
+        DynamoDBKey *key;
+        NSMutableArray *attributesToGet = [NSMutableArray array];
+        if(rangeKey == nil)
+        {
+            DynamoDBAttributeValue *attributeValueHashKeyValue = [self attributeValueFromObject:hashKey];
+            key = [[DynamoDBKey alloc] initWithHashKeyElement:attributeValueHashKeyValue];
+            
+            [attributesToGet addObject:[self hashKeyForEntityName:request.entity.name]];
+        }
+        else
+        {
+            DynamoDBAttributeValue *attributeValueHashKeyValue = [self attributeValueFromObject:hashKey];
+            DynamoDBAttributeValue *attributeValueRangeKeyValue = [self attributeValueFromObject:rangeKey];
+            key = [[DynamoDBKey alloc] initWithHashKeyElement:attributeValueHashKeyValue andRangeKeyElement:attributeValueRangeKeyValue];
+            
+            [attributesToGet addObject:[self hashKeyForEntityName:request.entity.name]];
+            [attributesToGet addObject:[self rangeKeyForEntityName:request.entity.name]];
+        }
+        
         DynamoDBGetItemRequest *getItemRequest = [[DynamoDBGetItemRequest alloc] initWithTableName:[self tableNameForEntityName:request.entity.name]
                                                                                             andKey:key];
         getItemRequest.consistentRead = YES;
-        getItemRequest.attributesToGet = [NSMutableArray arrayWithObject:[self hashKeyForEntityName:request.entity.name]];
+        getItemRequest.attributesToGet = attributesToGet;
 
         AmazonDynamoDBClient *dynamoDBClient = [self dynamoDBClient];
         DynamoDBGetItemResponse *getItemResponse = [dynamoDBClient getItem:getItemRequest];
@@ -528,28 +788,57 @@ NSString *const AWSPersistenceDynamoDBUserAgentPrefix = @"Persistence Framework"
         {
             if([getItemResponse.item count] > 0)
             {
-                attributeValue = (DynamoDBAttributeValue *)[getItemResponse.item objectForKey:[self hashKeyForEntityName:request.entity.name]];
-                NSString *hashKey;
-
-                if(attributeValue.s != nil)
-                {
-                    hashKey = attributeValue.s;
-                }
-                else if(attributeValue.n != nil)
-                {
-                    hashKey = attributeValue.n;
-                }
-
                 NSDictionary *attributeClasses = [self attributeClassesForClassName:request.entityName];
+                
+                NSString *hashKeyRetrieved;
+                NSString *rangeKeyRetrieved;
+                
+                DynamoDBAttributeValue *attributeValueHashKey = (DynamoDBAttributeValue *)[getItemResponse.item objectForKey:[self hashKeyForEntityName:request.entity.name]];
+                
+                if(attributeValueHashKey.s != nil)
+                {
+                    hashKeyRetrieved = attributeValueHashKey.s;
+                }
+                else if(attributeValueHashKey.n != nil)
+                {
+                    hashKeyRetrieved = attributeValueHashKey.n;
+                }
 
-                id hashKeyObject = [self convertString:hashKey toClass:[attributeClasses objectForKey:[self hashKeyForEntityName:request.entity.name]]];
+                
+                DynamoDBAttributeValue *attributeValueRangeKey = nil;
+                attributeValueRangeKey = (DynamoDBAttributeValue *)[getItemResponse.item objectForKey:[self rangeKeyForEntityName:request.entity.name]];
+                if(attributeValueRangeKey != nil)
+                {
+                    if(attributeValueRangeKey.s != nil)
+                    {
+                        rangeKeyRetrieved = attributeValueRangeKey.s;
+                    }
+                    else if(attributeValueRangeKey.n != nil)
+                    {
+                        rangeKeyRetrieved = attributeValueRangeKey.n;
+                    }
+                }
 
-                NSManagedObjectID *objectId = [self newObjectIDForEntity:request.entity
-                                                         referenceObject:hashKeyObject];
+                id hashKeyObject = [self convertString:hashKeyRetrieved toClass:[attributeClasses objectForKey:[self hashKeyForEntityName:request.entity.name]]];
+                id rangeKeyObject = nil;
+                if(rangeKeyRetrieved != nil)
+                {
+                    rangeKeyObject = [self convertString:rangeKeyRetrieved toClass:[attributeClasses objectForKey:[self rangeKeyForEntityName:request.entity.name]]];
+                }
+                
+                id key;
+                if(rangeKeyObject == nil)
+                {
+                    key = hashKeyObject;
+                }
+                else
+                {
+                    key = [NSDictionary dictionaryWithObjectsAndKeys:hashKeyObject, @"hashKey", rangeKeyObject, @"rangeKey", nil];
+                }
+                
+                NSManagedObjectID *objectId = [self newObjectIDForEntity:request.entity referenceObject:[self referenceObjectIdForCoreData:key]];
                 NSManagedObject *managedObject = [context objectWithID:objectId];
-
-                [objectIdToHashKey setValue:hashKeyObject forKey:objectId.URIRepresentation.description];
-
+                [objectIdToHashKey setValue:key forKey:objectId.URIRepresentation.description];
                 [resultArray addObject:managedObject];
             }
 
@@ -932,6 +1221,34 @@ NSString *const AWSPersistenceDynamoDBUserAgentPrefix = @"Persistence Framework"
 
 #pragma mark - Helper Methods
 
+- (NSString *)referenceObjectIdForCoreData:(id)hashKeyOrCompositeKey
+{
+    if([hashKeyOrCompositeKey isKindOfClass:[NSDictionary class]])
+    {
+        NSDictionary *compositeKey = hashKeyOrCompositeKey;
+        NSString *hashKey = [compositeKey objectForKey:@"hashKey"];
+        id rangeKey = [compositeKey objectForKey:@"rangeKey"];
+        if([rangeKey isKindOfClass:[NSDate class]])
+        {
+            NSDate  *rangeKeyAsDate = rangeKey;
+            rangeKey = [NSNumber numberWithDouble:[rangeKeyAsDate timeIntervalSince1970]];
+        }
+        else
+        {
+            
+        }
+
+        
+        NSString *compositeKeyAsString = [NSString stringWithFormat:@"--HK--%@----RK--%@--", hashKey, rangeKey];
+        return compositeKeyAsString;
+    }
+    else
+    {
+        NSString *hashKey = hashKeyOrCompositeKey;
+        return hashKey;
+    }
+}
+
 - (DynamoDBAttributeValue *)attributeValueFromObject:(NSObject *)object
 {
     DynamoDBAttributeValue *attributeValue;
@@ -1080,6 +1397,11 @@ NSString *const AWSPersistenceDynamoDBUserAgentPrefix = @"Persistence Framework"
 - (NSString *)hashKeyForEntityName:(NSString *)entityName
 {
     return [[self.options valueForKey:AWSPersistenceDynamoDBHashKey] valueForKey:entityName];
+}
+
+- (NSString *)rangeKeyForEntityName:(NSString *)entityName
+{
+    return [[self.options valueForKey:AWSPersistenceDynamoDBRangeKey] valueForKey:entityName];
 }
 
 - (NSString *)versionKeyForEntityName:(NSString *)entityName


### PR DESCRIPTION
Modifications toward supporting range keys in the DynamoDB for Core Data. Tested changes include creating new entity instances that have range keys, requesting single items using hash+range, and requesting a range of results using a hash key, upper and lower bounds on range key, result limit, and  sort direction.

Additional work may be needed in order to support:
- range key for proper uniqueness in -obtainPermanentIDsForObjects.
- Core Data Relationships based on range keys (we do not use Core Data relationships heavily in our project).

Example usage:

<pre>
// Result variables.
NSArray* items = nil;
NSError* error = nil;
     
// Prepare context and fetch request.
id context = ...;
NSEntityDescription* entityDescription = ...;
NSFetchRequest* request = [[NSFetchRequest alloc] init];
[request setEntity:entityDescription];

// Prepare range key upper and lower bounds.
NSDate* upperBound = [NSDate date];
NSDate* lowerBound = [NSDate dateWithTimeIntervalSince1970:0];

// Setup hash key and range key bounds in predicate.
NSPredicate* predicate =
[NSPredicate predicateWithFormat:@"myHashKey == %@ AND myRangeKey BETWEEN %@", userId, [NSArray arrayWithObjects: lowerBound, upperBound, nil]];
[request setPredicate:predicate];

// Set max results.
[request setFetchLimit:maxResults];

// Setup sort direction.
NSSortDescriptor* sort = [NSSortDescriptor sortDescriptorWithKey:@"timestamp" ascending:NO];
[request setSortDescriptors:[NSArray arrayWithObject:sort]];

// Execute request
items  = [context executeFetchRequest:request error:&error];
</pre>
