### PR TITLE
Support for S3 Multipart Uploads to be cancelled before they are finished

### DIFF
--- a/src/Amazon.S3/Model/S3MultipartUploadOperation_Internal.m
+++ b/src/Amazon.S3/Model/S3MultipartUploadOperation_Internal.m
@@ -266,6 +266,11 @@ typedef void (^AbortMultipartUploadBlock)();
             {
 
                 if([self isCancelled]) {
+                    if(self.request.stream)
+                    {
+                        [self.request.stream close];
+                    }
+                    
                     if(self.abortMultipartUpload)
                     {
                         dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
@@ -395,7 +400,8 @@ typedef void (^AbortMultipartUploadBlock)();
 
         if((self.s3.maxRetries > self.retryCount && (self.error || self.exception))
            && [self.s3 shouldRetry:nil exception:self.exception]
-           && [self isExecuting])
+           && [self isExecuting]
+           && ![self isCancelled])
         {
             AMZLogDebug(@"Retrying %@", [request class]);
 


### PR DESCRIPTION
S3TransferManager handles multipart uploads as NSOperations via the S3MultipartUploadOperation_Internal.m class.

My implementation checks [self isCancelled] at two points:
- Between each upload in a multipart upload
- Before each retry in a retry scenario

This allows for long running multipart uploads to be cancelled before they are completed by calling [transferManager.operationQueue cancelAllOperations];

This is useful if the device transitions from a WiFi connection to a Cellular connection, and we want to avoid the data plan overage impact of a very large upload.

Related: [NSOperation Class Reference: "Responding to the Cancel Command"](http://developer.apple.com/library/mac/#documentation/Cocoa/Reference/NSOperation_class/Reference/Reference.html#//apple_ref/doc/uid/TP40004591-RH2-SW18)
