### PR TITLE
Cancellation support for S3PutObjectOperation_internal.m

### DIFF
--- a/src/Amazon.S3/Model/S3PutObjectOperation_Internal.m
+++ b/src/Amazon.S3/Model/S3PutObjectOperation_Internal.m
@@ -76,11 +76,9 @@
         return;
     }
     if([self isCancelled]) {
-        if(self.request) {
-            [self.request cancel];
-        }
+        [self.request cancel];
         [self finish];
-        return;
+      return;
     }
 
     [self willChangeValueForKey:@"isExecuting"];
@@ -150,7 +148,10 @@
 - (void)request:(AmazonServiceRequest *)request didFailWithError:(NSError *)error
 {
     AMZLogDebug(@"%@", error);
+
+    // exit as soon as possible on cancellation to skip the retry logic
     if([self isCancelled]) {
+        [self.request cancel];
         [self finish];
         return;
     }
@@ -179,7 +180,10 @@
 - (void)request:(AmazonServiceRequest *)request didFailWithServiceException:(NSException *)exception
 {
     AMZLogDebug(@"%@", exception);
+    
+    // if cancelled exit as quickly as possible to avoid the retry logic
     if([self isCancelled]) {
+        [self.request cancel];
         [self finish];
         return;
     }


### PR DESCRIPTION
Implmented proper cancellation support for S3PutObjectOperation_internal.m. The current implementation does not properly respond to cancel requests which is especially important if you have pending S3 uploads and need to shut down your network stack.

This is implementation is a tad bit aggressive in that I check in every delegate method for cancelation support as well as overriding the cancel method to cancel the outstanding request and mark the NSOperation as finished.
