### PR TITLE
Bug Fix: The S3 server throws 403 error if Date Header for a S3GetObject...

### DIFF
--- a/src/Amazon.S3/Model/S3Request.m
+++ b/src/Amazon.S3/Model/S3Request.m
@@ -28,6 +28,8 @@
     [self.urlRequest setValue:[NSString stringWithFormat:@"%lld", self.contentLength] forHTTPHeaderField:kHttpHdrContentLength];
 
     [self.urlRequest setValue:self.host forHTTPHeaderField:kHttpHdrHost];
+    
+    self.date = [NSDate date];
     [self.urlRequest setValue:[self.date stringWithRFC822Format] forHTTPHeaderField:kHttpHdrDate];
 
     if (nil != self.httpMethod) {


### PR DESCRIPTION
...Request is more

than 15 minutes old.

When the S3TransferManager is used, the date property for a S3Request is set when the
downloadFile:bucket:key: is made rather than when the download begins.  For large multi file
downloads, this causes any download started 15 minutes after the initial download to fail
with a 403 error.

See: https://github.com/aws/aws-sdk-ios/issues/43
