### PR TITLE
Support for cancelling the request immediately

### DIFF
--- a/src/Amazon.S3/Model/S3PutObjectOperation_Internal.m
+++ b/src/Amazon.S3/Model/S3PutObjectOperation_Internal.m
@@ -234,13 +234,14 @@
     [self didChangeValueForKey:@"isFinished"];
 }
 
-#pragma mark - Cancel immediately
+#pragma mark - Override Cancel
 -(void)cancel {
-    [self.putRequest cancel];
     [super cancel];
-    
-    [self cleanup];
-    [self finish];
+    if(_isExecuting) {
+        [self.putRequest cancel];
+        [self cleanup];
+        [self finish];
+    }
 }
 
 #pragma mark -

--- a/src/Amazon.S3/Model/S3PutObjectOperation_Internal.m
+++ b/src/Amazon.S3/Model/S3PutObjectOperation_Internal.m
@@ -234,6 +234,15 @@
     [self didChangeValueForKey:@"isFinished"];
 }
 
+#pragma mark - Cancel immediately
+-(void)cancel {
+    [self.putRequest cancel];
+    [super cancel];
+    
+    [self cleanup];
+    [self finish];
+}
+
 #pragma mark -
 
 @end


### PR DESCRIPTION
Rather than wait for a callback to come from AmazonServiceRequestDelegate, why don't we cancel it immediately? 
In case the upload has stalled, none of the delegate methods are called and hence the operation never gets cancelled.

I am relatively new to Objective C, so if this is a big blunder, please let me know.
