### PR TITLE
Don't sign S3 requests if an Authorization header has already been set

### DIFF
--- a/src/Amazon.S3/AmazonS3Client.m
+++ b/src/Amazon.S3/AmazonS3Client.m
@@ -447,7 +447,13 @@
             request.date = [NSDate date];
         }
 
-        NSMutableURLRequest *urlRequest = [self signS3Request:request];
+        NSMutableURLRequest *urlRequest;
+        if (request.authorization == nil) {
+            urlRequest = [self signS3Request:request];
+        }
+        else {
+            urlRequest = [request configureURLRequest];
+        }
 
         if (self.connectionTimeout != 0) {
             [urlRequest setTimeoutInterval:self.connectionTimeout];


### PR DESCRIPTION
This allows for remotely signed headers to be used with the client library. An
example setup is:
1. iOS client computes the SHA256 of an object and sends its name (S3 key), the
   SHA256 hash, and other fields (e.g. Content-Length) to a signing server
2. signing server validates the fields and creates a set of signed headers
   including the Authorization headers using the v4 signing scheme
3. iOS client applies those headers to the S3Request and its underlying
   NSMutableURLRequest appropriately
4. iOS client calls -[AmazonS3Client putObject:s3Request]

Currently step (4) re-signs the upload request using the client's credentials.
By checking whether the "authorization" property has been set we can determine
whether the client intended to manage its own authorization headers.
