### PR TITLE
Significant speedup by reusing a static NSDateFormatter instance.

### DIFF
--- a/src/Amazon.Runtime/AmazonSDKUtil.m
+++ b/src/Amazon.Runtime/AmazonSDKUtil.m
@@ -329,34 +329,34 @@ static NSTimeInterval _clockskew = 0.0;
 
 +(NSDate *)convertStringToDate:(NSString *)string usingFormat:(NSString *)dateFormat
 {
-    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-
-    [dateFormatter setDateFormat:dateFormat];
-    [dateFormatter setLocale:[AmazonSDKUtil timestampLocale]];
-    [dateFormatter setTimeZone:[NSTimeZone timeZoneWithName:@"GMT"]];
+    static NSDateFormatter *dateFormatter = nil;
+    if (!dateFormatter) {
+        dateFormatter = [[NSDateFormatter alloc] init];
+        [dateFormatter setDateFormat:dateFormat];
+        [dateFormatter setLocale:[AmazonSDKUtil timestampLocale]];
+        [dateFormatter setTimeZone:[NSTimeZone timeZoneWithName:@"GMT"]];
+    }
 
     NSDate *parsed = [dateFormatter dateFromString:string];
 
     NSDate *localDate = [parsed dateByAddingTimeInterval:_clockskew];
-    
-    [dateFormatter release];
     
     return localDate;
 }
 
 +(NSString *)convertDateToString:(NSDate *)date usingFormat:(NSString *)dateFormat
 {
-    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-    
-    [dateFormatter setTimeZone:[NSTimeZone timeZoneWithName:@"GMT"]];
-    [dateFormatter setDateFormat:dateFormat];
-    [dateFormatter setLocale:[AmazonSDKUtil timestampLocale]];
+    static NSDateFormatter *dateFormatter = nil;
+    if (!dateFormatter) {
+        dateFormatter = [[NSDateFormatter alloc] init];
+        [dateFormatter setTimeZone:[NSTimeZone timeZoneWithName:@"GMT"]];
+        [dateFormatter setDateFormat:dateFormat];
+        [dateFormatter setLocale:[AmazonSDKUtil timestampLocale]];
+    }
     
     NSDate *realDate =  [date dateByAddingTimeInterval:-1*_clockskew];
     
     NSString *formatted = [dateFormatter stringFromDate:realDate];
-    
-    [dateFormatter release];
     
     return formatted;
 }

--- a/src/Amazon.Runtime/AmazonSDKUtil.m
+++ b/src/Amazon.Runtime/AmazonSDKUtil.m
@@ -329,13 +329,14 @@ static NSTimeInterval _clockskew = 0.0;
 
 +(NSDate *)convertStringToDate:(NSString *)string usingFormat:(NSString *)dateFormat
 {
-    static NSDateFormatter *dateFormatter = nil;
-    if (!dateFormatter) {
+    static NSDateFormatter *dateFormatter;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
         dateFormatter = [[NSDateFormatter alloc] init];
         [dateFormatter setDateFormat:dateFormat];
         [dateFormatter setLocale:[AmazonSDKUtil timestampLocale]];
         [dateFormatter setTimeZone:[NSTimeZone timeZoneWithName:@"GMT"]];
-    }
+    });
 
     NSDate *parsed = [dateFormatter dateFromString:string];
 
@@ -346,13 +347,14 @@ static NSTimeInterval _clockskew = 0.0;
 
 +(NSString *)convertDateToString:(NSDate *)date usingFormat:(NSString *)dateFormat
 {
-    static NSDateFormatter *dateFormatter = nil;
-    if (!dateFormatter) {
+    static NSDateFormatter *dateFormatter;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
         dateFormatter = [[NSDateFormatter alloc] init];
         [dateFormatter setTimeZone:[NSTimeZone timeZoneWithName:@"GMT"]];
         [dateFormatter setDateFormat:dateFormat];
         [dateFormatter setLocale:[AmazonSDKUtil timestampLocale]];
-    }
+    });
     
     NSDate *realDate =  [date dateByAddingTimeInterval:-1*_clockskew];
     


### PR DESCRIPTION
Instantiating a NSDateFormatter instance is terribly slow, as documented a couple of places:

http://patzearfoss.com/2011/09/22/in-case-you-didnt-know-nsdateformatter-is-slooooow/
https://alpha.app.net/tewha/post/8055698
http://cocoaintheshell.com/2010/08/nsdateformatter-performances/

Holding on to a single static date formatter instance has neglible memory impact while increasing performance significantly.
