### PR TITLE
RU-808: Fix S3 Put Crash

### DIFF
--- a/src/Amazon.S3/Model/S3PutObjectOperation_Internal.m
+++ b/src/Amazon.S3/Model/S3PutObjectOperation_Internal.m
@@ -23,7 +23,7 @@
 }
 
 @property (nonatomic, assign) NSInteger retryCount;
-@property (nonatomic, assign) id<AmazonServiceRequestDelegate> delegate;
+@property (nonatomic, weak) id<AmazonServiceRequestDelegate> delegate;
 
 @end
 
@@ -49,9 +49,6 @@
 
 - (void)dealloc
 {
-    [_response release];
-    
-    [super dealloc];
 }
 
 #pragma mark - Overriding NSOperation Methods

--- a/src/S3.xcodeproj/project.pbxproj
+++ b/src/S3.xcodeproj/project.pbxproj
@@ -166,7 +166,7 @@
 		AACBBE4A0F95108600F1A2B1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AACBBE490F95108600F1A2B1 /* Foundation.framework */; };
 		CE2BF33C16CB32C2005189A8 /* S3AbortMultipartUploadsOperation_Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = CE2BF33616CB32C2005189A8 /* S3AbortMultipartUploadsOperation_Internal.m */; };
 		CE2BF33E16CB32C2005189A8 /* S3MultipartUploadOperation_Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = CE2BF33816CB32C2005189A8 /* S3MultipartUploadOperation_Internal.m */; };
-		CE2BF34016CB32C2005189A8 /* S3PutObjectOperation_Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = CE2BF33A16CB32C2005189A8 /* S3PutObjectOperation_Internal.m */; };
+		CE2BF34016CB32C2005189A8 /* S3PutObjectOperation_Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = CE2BF33A16CB32C2005189A8 /* S3PutObjectOperation_Internal.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		CE2BF34216CB32CF005189A8 /* S3TransferManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CE2BF34116CB32CF005189A8 /* S3TransferManager.m */; };
 		CE2CDBFE17036F640013DE5F /* AWSS3.h in Headers */ = {isa = PBXBuildFile; fileRef = CE2CDBFD17036F640013DE5F /* AWSS3.h */; };
 		CE8EF5F016F941A4007BF85E /* AmazonS3Client.h in Headers */ = {isa = PBXBuildFile; fileRef = CE8EF55216F941A3007BF85E /* AmazonS3Client.h */; };
@@ -1505,7 +1505,7 @@
 				GCC_PREFIX_HEADER = S3_Prefix.pch;
 				HEADER_SEARCH_PATHS = include;
 				INSTALL_PATH = /usr/local/lib;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = (
 					"-all_load",
 					"-ObjC",
@@ -1530,7 +1530,7 @@
 				GCC_PREFIX_HEADER = S3_Prefix.pch;
 				HEADER_SEARCH_PATHS = include;
 				INSTALL_PATH = /usr/local/lib;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = (
 					"-all_load",
 					"-ObjC",
@@ -1615,7 +1615,7 @@
 				GCC_PREFIX_HEADER = S3_Prefix.pch;
 				HEADER_SEARCH_PATHS = include;
 				INSTALL_PATH = /usr/local/lib;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = (
 					"-all_load",
 					"-ObjC",
@@ -1673,7 +1673,7 @@
 				GCC_PREFIX_HEADER = S3_Prefix.pch;
 				HEADER_SEARCH_PATHS = include;
 				INSTALL_PATH = /usr/local/lib;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = (
 					"-all_load",
 					"-ObjC",


### PR DESCRIPTION
This PR fixes one of our [top crashes in 4.5.11](https://rink.hockeyapp.net/manage/apps/14630/app_versions/130/crash_reasons/103173664).    The root of the problem is that the delegate is being released before the operation is finished processing.  The fix is to make a weak reference that will nil out the reference on release.  

###### Why not upgrade to AWS SDK v2?  
We've chosen to fix the current deprecated API because efforts to update were taking longer than expected.  We do still expect to upgrade in the coming months.  When that occurs we can deprecate our fork of the deprecated SDK.

This is being merged into with https://github.com/hudl/modi/pull/2665.  It will be tested on that PR.

